### PR TITLE
adds review note as comment

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -51,5 +51,13 @@ function imageClicked(){
     bigGrid.style.top =  " " + (currYOffset+30) + "px";
     console.log(currYOffset);
 
+    // I like this! You identified an issue
+    // with the UI ("User can no longer see the image if they scroll down.")
+    // and then wrote code to deal with it.
+    // There are other approaches, though. For example,
+    // you could make the thumbnails scroll independently
+    // by adding this style to the thumbnail container: `overflow-y: auto` and setting
+    // the big image to `position: absolute`.
+    
 }
 


### PR DESCRIPTION
Nice work! I added a comment to `index.js` regarding an alternate technique for getting the big image to stay in view. I'd say that solving it with CSS is slightly more maintainable than doing it in JS. But only because you can make adjustments in your media queries as you scale to larger screens.